### PR TITLE
test: enforce docs hygiene

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,37 @@
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+README = os.path.join(REPO_ROOT, "README.md")
+MODEL_CARD = os.path.join(REPO_ROOT, "MODEL_CARD.md")
+
+FORBIDDEN_TERMS = ["Claude", "Sonnet", "Opus", "Anthropic"]
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_readme_exists() -> None:
+    assert os.path.isfile(README), "README.md must exist at repo root"
+    assert _read(README).strip(), "README.md must not be empty"
+
+
+def test_model_card_exists() -> None:
+    assert os.path.isfile(MODEL_CARD), "MODEL_CARD.md must exist at repo root"
+    assert _read(MODEL_CARD).strip(), "MODEL_CARD.md must not be empty"
+
+
+def test_model_card_has_limitations() -> None:
+    body = _read(MODEL_CARD)
+    assert re.search(
+        r"^##\s+Known Limitations\s*$", body, flags=re.MULTILINE
+    ), "MODEL_CARD.md must contain a '## Known Limitations' section"
+
+
+def test_no_claude_mentions() -> None:
+    for path in (README, MODEL_CARD):
+        body = _read(path)
+        hits = [t for t in FORBIDDEN_TERMS if re.search(rf"\b{t}\b", body)]
+        assert not hits, f"{os.path.basename(path)} contains forbidden terms: {hits}"


### PR DESCRIPTION
## Summary
- Adds tests/test_docs.py with 4 checks:
  - test_readme_exists — README.md present and non-empty.
  - test_model_card_exists — MODEL_CARD.md present and non-empty.
  - test_model_card_has_limitations — '## Known Limitations' header present.
  - test_no_claude_mentions — neither file contains the word-boundary tokens Claude / Sonnet / Opus / Anthropic.
- Word-boundary regex avoids false positives on the gitignored CLAUDE.md filename if it ever gets referenced.
- Uses built-in open() per C10. Imports at module top per C25.

Closes #19

## Test plan
- [x] All 4 tests pass locally (pytest tests/test_docs.py -v).
- [ ] Full gate (black/isort/flake8/mypy/bandit/pytest --cov-fail-under=70) passes after merge.