### PR TITLE
fix(hf-space): restore tab clickability

### DIFF
--- a/hf_space/app.py
+++ b/hf_space/app.py
@@ -413,6 +413,38 @@ _CSS = """
     font-size: 0.85rem;
     border-radius: 0 6px 6px 0;
 }
+/* ── Tab visibility + clickability ─────────────────────────────────
+ * Without these rules the inline white-on-dark hero/footer styles
+ * land on Gradio's default theme and tab labels render with low
+ * contrast — users see tabs as "unclickable" because the labels
+ * are barely visible. These rules force a readable, hoverable,
+ * always-clickable tab strip without overriding the rest of the
+ * theme.
+ */
+button[role="tab"] {
+    color: rgba(255, 255, 255, 0.7) !important;
+    background: transparent !important;
+    border: none !important;
+    padding: 10px 18px !important;
+    font-weight: 500 !important;
+    cursor: pointer !important;
+    pointer-events: auto !important;
+    opacity: 1 !important;
+}
+button[role="tab"]:hover {
+    color: #ffffff !important;
+    background: rgba(99, 102, 241, 0.12) !important;
+}
+button[role="tab"][aria-selected="true"],
+button[role="tab"].selected {
+    color: #ffffff !important;
+    border-bottom: 2px solid #6366f1 !important;
+}
+/* Ensure the tab strip itself isn't covered by any sibling */
+div[role="tablist"] {
+    position: relative;
+    z-index: 10;
+}
 """
 
 _HERO = """
@@ -648,8 +680,18 @@ def build_app() -> gr.Blocks:
 
 
 if __name__ == "__main__":
+    # Gradio 6: theme + css belong on launch(), not on gr.Blocks().
+    # Dark-friendly Base theme so the white-text hero/footer HTML render
+    # against a dark surface — without this the inline-styled subtitles
+    # are invisible and the tab labels look low-contrast / unclickable.
+    _theme = gr.themes.Base(
+        primary_hue="indigo",
+        secondary_hue="purple",
+        neutral_hue="slate",
+    )
     demo = build_app()
     demo.launch(
+        theme=_theme,
         css=_CSS,
         server_name="0.0.0.0",
         server_port=7860,


### PR DESCRIPTION
## Summary
The non-active tabs in the live Space were effectively unclickable — either invisible or low-contrast. Two concurrent regressions caused it:

1. **Commit ccc88a7** stripped all Gradio CSS overrides, including the \`button[role=\"tab\"]\` visibility rules added in 9b5331a. With Gradio's default theme but white-text hero/footer HTML, the tab labels rendered as low-contrast on the resulting surface.
2. **Commit ccc88a7** also stripped the \`gr.themes.Base()\` dark theme added in 903ddd8, so the light Gradio default was back but the inline white-text styles weren't updated to match.

Additionally, **Gradio 6 moved \`theme=\` from \`gr.Blocks()\` to \`launch()\`** (same as \`css=\`). If I had re-added the theme on Blocks it would have issued a deprecation warning and been ignored.

## Changes
- Re-added minimal \`button[role=\"tab\"]\` CSS: readable color, hover state, selected-state underline, explicit \`pointer-events: auto\`, and \`z-index: 10\` on the tablist so nothing can cover it. Surgical — not the full CSS overhaul from 903ddd8.
- Re-added \`gr.themes.Base(primary_hue=indigo, secondary_hue=purple, neutral_hue=slate)\` — passed to \`launch()\`, not \`Blocks()\`, per Gradio 6.
- Verified locally: \`build_app()\` produces 6 Tab children + 2 Tabs parents with no theme-placement warning.

Closes #26

## Test plan
- [x] \`py -3.10 -c \"import app; app.build_app()\"\` — no warnings, 6 tabs.
- [x] Full exit gate green (172 tests, 84.32% coverage, 0 mypy / bandit H-M).
- [ ] After merge: re-upload \`hf_space/\` to the live Space and confirm all four tabs click + render.