### PR TITLE
chore: add quality gates to Makefile (complexity, docstrings, audit)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,16 @@ test:
 	pytest tests/ -v --tb=short --cov=src --cov-fail-under=70
 
 security:
-	bandit -r src/ -ll -ii && pip-audit -r requirements.txt
+	bandit -r src/ -ll -ii
+
+complexity:
+	radon cc src/ -nc
+
+docstrings:
+	interrogate src/ --fail-under=80
+
+audit:
+	pip-audit -r requirements.txt && detect-secrets scan --baseline .secrets.baseline
 
 train-baseline:
 	python -m src.baseline.train_baseline


### PR DESCRIPTION
## Summary
- Adds `make complexity` — runs `radon cc src/ -nc` to flag functions above grade B
- Adds `make docstrings` — runs `interrogate src/ --fail-under=80`
- Adds `make audit` — runs `pip-audit` + `detect-secrets scan`
- Splits old `security` target (bandit only) from the new `audit` target

## Test plan
- [ ] `make complexity` exits 0 after complexity PRs are merged
- [ ] `make docstrings` exits 0 after docstring PR is merged
- [ ] `make audit` exits 0 after detect-secrets baseline is initialized

Closes #33