### PR TITLE
refactor: reduce complexity in train_stage_a, compare_baseline_vs_hybrid, collect* functions

### DIFF
--- a/src/data/collect.py
+++ b/src/data/collect.py
@@ -258,47 +258,55 @@ def collect_spml_injections(max_samples: int | None = None) -> pd.DataFrame:
         return pd.DataFrame(columns=SCHEMA_COLUMNS)
 
 
+def _collect_from_c4(cap: int) -> list[dict[str, Any]]:
+    """Return up to cap rows from allenai/c4 validation split."""
+    from datasets import load_dataset  # type: ignore[import-untyped]
+
+    rows: list[dict[str, Any]] = []
+    ds = load_dataset("allenai/c4", "en", split="validation", streaming=True)  # nosec B615
+    for i, item in enumerate(ds):
+        if len(rows) >= cap:
+            break
+        text = str(item.get("text", "")).strip()
+        if len(text) < 20:
+            continue
+        rows.append(_build_row(text[:512], 0, "c4_safe", "web", i))
+    logger.info("c4 safe corpus: %d rows loaded", len(rows))
+    return rows
+
+
+def _collect_from_openwebtext(cap: int) -> list[dict[str, Any]]:
+    """Return up to cap rows from stas/openwebtext-10k as a fallback."""
+    from datasets import load_dataset  # type: ignore[import-untyped]
+
+    rows: list[dict[str, Any]] = []
+    ds = load_dataset("stas/openwebtext-10k", split="train")  # nosec B615
+    for i, item in enumerate(ds):
+        if len(rows) >= cap:
+            break
+        text = str(item.get("text", "")).strip()
+        if len(text) < 20:
+            continue
+        rows.append(_build_row(text[:512], 0, "openwebtext", "web", i))
+    logger.info("openwebtext safe corpus: %d rows loaded", len(rows))
+    return rows
+
+
 def collect_safe_corpus(max_samples: int | None = None) -> pd.DataFrame:
     """
     Load safe/benign text examples from allenai/c4 (en, validation split).
     Fallback: stas/openwebtext-10k. Label=0 (safe).
     """
-    from datasets import load_dataset  # type: ignore[import-untyped]
-
     logger.info("Loading safe corpus")
     cap = max_samples if max_samples is not None else 15000
     rows: list[dict[str, Any]] = []
 
     try:
-        ds = load_dataset(  # nosec B615
-            "allenai/c4",
-            "en",
-            split="validation",
-            streaming=True,
-        )
-        for i, item in enumerate(ds):
-            if len(rows) >= cap:
-                break
-            text = str(item.get("text", "")).strip()
-            if len(text) < 20:
-                continue
-            # Keep only sentences that are clearly safe (short snippet, no commands)
-            snippet = text[:512]
-            rows.append(_build_row(snippet, 0, "c4_safe", "web", i))
-        logger.info("c4 safe corpus: %d rows loaded", len(rows))
+        rows = _collect_from_c4(cap)
     except Exception as exc:
         logger.warning("c4 unavailable (%s), falling back to openwebtext-10k", exc)
         try:
-            ds2 = load_dataset("stas/openwebtext-10k", split="train")  # nosec B615
-            for i, item in enumerate(ds2):
-                if len(rows) >= cap:
-                    break
-                text = str(item.get("text", "")).strip()
-                if len(text) < 20:
-                    continue
-                snippet = text[:512]
-                rows.append(_build_row(snippet, 0, "openwebtext", "web", i))
-            logger.info("openwebtext safe corpus: %d rows loaded", len(rows))
+            rows = _collect_from_openwebtext(cap)
         except Exception as exc2:
             logger.error("Both safe corpus sources failed: %s", exc2)
 
@@ -351,6 +359,36 @@ def collect_safe_questions(max_samples: int | None = None) -> pd.DataFrame:
     return pd.DataFrame(columns=SCHEMA_COLUMNS)
 
 
+_SOURCE_DISPATCH: dict[str, Any] = {
+    "jailbreakbench": "collect_jailbreakbench",
+    "advbench": "collect_advbench",
+    "advbench_csv": "collect_advbench_csv",
+    "wildjailbreak": "collect_jackhhao_jailbreak",
+    "jackhhao": "collect_jackhhao_jailbreak",
+    "deepset_prompt_injections": "collect_prompt_injections",
+    "bipia_slices": "collect_spml_injections",
+    "spml_injections": "collect_spml_injections",
+    "safe_corpus": "collect_safe_corpus",
+    "safe_questions": "collect_safe_questions",
+}
+
+
+def _collect_frames(
+    sources: list[str], max_per_source: int | None
+) -> list[pd.DataFrame]:
+    """Dispatch each source name to its collector function; return collected frames."""
+    import sys
+
+    module = sys.modules[__name__]
+    frames: list[pd.DataFrame] = []
+    for src in sources:
+        fn_name = _SOURCE_DISPATCH.get(src)
+        if fn_name is not None:
+            fn = getattr(module, fn_name)
+            frames.append(fn(max_per_source))
+    return frames
+
+
 def collect_all_sources(config: dict[str, Any]) -> pd.DataFrame:
     """
     Merge all 5 sources into a unified DataFrame with the canonical schema.
@@ -375,28 +413,7 @@ def collect_all_sources(config: dict[str, Any]) -> pd.DataFrame:
 
     logger.info("Collecting data from sources: %s", sources)
 
-    frames: list[pd.DataFrame] = []
-
-    if "jailbreakbench" in sources:
-        frames.append(collect_jailbreakbench(max_per_source))
-    if "advbench" in sources:
-        frames.append(collect_advbench(max_per_source))
-    if "advbench_csv" in sources:
-        frames.append(collect_advbench_csv(max_per_source))
-    if "wildjailbreak" in sources:
-        frames.append(collect_jackhhao_jailbreak(max_per_source))
-    if "jackhhao" in sources:
-        frames.append(collect_jackhhao_jailbreak(max_per_source))
-    if "deepset_prompt_injections" in sources:
-        frames.append(collect_prompt_injections(max_per_source))
-    if "bipia_slices" in sources:
-        frames.append(collect_spml_injections(max_per_source))
-    if "spml_injections" in sources:
-        frames.append(collect_spml_injections(max_per_source))
-    if "safe_corpus" in sources:
-        frames.append(collect_safe_corpus(max_per_source))
-    if "safe_questions" in sources:
-        frames.append(collect_safe_questions(max_per_source))
+    frames = _collect_frames(sources, max_per_source)
 
     if not frames:
         logger.warning("No source frames collected — returning empty DataFrame")

--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -416,6 +416,50 @@ def _time_stage_a_onnx(config: dict[str, Any], texts: list[str]) -> list[float]:
 # ---------------------------------------------------------------------------
 
 
+def _save_one_attribution(
+    i: int,
+    text: str,
+    explainer: Optional[Any],
+    figures_dir: str,
+) -> None:
+    """Save HTML and PNG attribution files for a single sample."""
+    import matplotlib.pyplot as plt
+
+    attributions: list[dict[str, str | float]] = []
+    try:
+        if explainer is not None:
+            raw = explainer.explain(text)
+            attributions = [
+                {"token": str(item["token"]), "score": float(item["score"])}
+                for item in raw
+            ]
+    except Exception as exc:
+        logger.warning("attribution_failed", extra={"i": i, "err": str(exc)})
+
+    html_path = os.path.join(figures_dir, f"token_attribution_sample_{i}.html")
+    with open(html_path, "w", encoding="utf-8") as fh:
+        fh.write(_render_attribution_html(text, attributions))
+
+    png_path = os.path.join(figures_dir, f"token_attribution_sample_{i}.png")
+    tokens = [str(a["token"]) for a in attributions[:20]]
+    scores = [float(a["score"]) for a in attributions[:20]]
+    if tokens:
+        colors = ["red" if s > 0 else "blue" for s in scores]
+        fig, ax = plt.subplots(figsize=(max(6, len(tokens) * 0.5), 4))
+        ax.bar(range(len(tokens)), scores, color=colors)
+        ax.set_xticks(list(range(len(tokens))))
+        ax.set_xticklabels(tokens, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel("Attribution Score")
+        ax.set_title(f"Token Attribution — sample {i}")
+    else:
+        fig, ax = plt.subplots(figsize=(4, 2))
+        ax.text(0.5, 0.5, "No attributions", ha="center", va="center")
+        ax.axis("off")
+    plt.tight_layout()
+    fig.savefig(png_path)
+    plt.close(fig)
+
+
 def generate_explainability_samples(
     pipeline: Any,
     test_data: Any,
@@ -434,7 +478,6 @@ def generate_explainability_samples(
     import matplotlib
 
     matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
 
     os.makedirs(figures_dir, exist_ok=True)
 
@@ -450,44 +493,7 @@ def generate_explainability_samples(
     explainer = _build_explainer(pipeline)
 
     for i, text in enumerate(samples):
-        attributions: list[dict[str, str | float]] = []
-        try:
-            if explainer is not None:
-                raw = explainer.explain(text)
-                attributions = [
-                    {
-                        "token": str(item["token"]),
-                        "score": float(item["score"]),
-                    }
-                    for item in raw
-                ]
-        except Exception as exc:
-            logger.warning("attribution_failed", extra={"i": i, "err": str(exc)})
-
-        # HTML
-        html_path = os.path.join(figures_dir, f"token_attribution_sample_{i}.html")
-        with open(html_path, "w", encoding="utf-8") as fh:
-            fh.write(_render_attribution_html(text, attributions))
-
-        # PNG
-        png_path = os.path.join(figures_dir, f"token_attribution_sample_{i}.png")
-        tokens = [str(a["token"]) for a in attributions[:20]]
-        scores = [float(a["score"]) for a in attributions[:20]]
-        if tokens:
-            colors = ["red" if s > 0 else "blue" for s in scores]
-            fig, ax = plt.subplots(figsize=(max(6, len(tokens) * 0.5), 4))
-            ax.bar(range(len(tokens)), scores, color=colors)
-            ax.set_xticks(list(range(len(tokens))))
-            ax.set_xticklabels(tokens, rotation=45, ha="right", fontsize=8)
-            ax.set_ylabel("Attribution Score")
-            ax.set_title(f"Token Attribution — sample {i}")
-        else:
-            fig, ax = plt.subplots(figsize=(4, 2))
-            ax.text(0.5, 0.5, "No attributions", ha="center", va="center")
-            ax.axis("off")
-        plt.tight_layout()
-        fig.savefig(png_path)
-        plt.close(fig)
+        _save_one_attribution(i, text, explainer, figures_dir)
 
     logger.info(
         "explainability_samples_saved",
@@ -540,6 +546,85 @@ def _render_attribution_html(
         "<html><head><meta charset='utf-8'></head>"
         f"<body style='font-family:monospace;padding:16px'>{body}</body></html>"
     )
+
+
+# ---------------------------------------------------------------------------
+# compare_baseline_vs_hybrid helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge_results_json(
+    results_path: str,
+    baseline_row: dict[str, str | float],
+    hybrid_row: dict[str, str | float],
+) -> None:
+    """Load (or create) results.json and upsert the two benchmark rows."""
+    os.makedirs(os.path.dirname(results_path), exist_ok=True)
+    if os.path.exists(results_path):
+        with open(results_path) as f:
+            results: dict[str, Any] = json.load(f)
+        results["benchmarks"] = [
+            b
+            for b in results.get("benchmarks", [])
+            if b.get("model")
+            not in (str(baseline_row["model"]), str(hybrid_row["model"]))
+        ]
+        results["benchmarks"].extend([baseline_row, hybrid_row])
+    else:
+        results = {
+            "project": "P1-Hybrid-Jailbreak-Detector",
+            "benchmarks": [baseline_row, hybrid_row],
+        }
+    with open(results_path, "w") as f:
+        json.dump(results, f, indent=2)
+    logger.info("results_json_updated", extra={"path": results_path})
+
+
+def _print_comparison_table(
+    baseline_row: dict[str, str | float],
+    hybrid_row: dict[str, str | float],
+    scalar_keys: list[str],
+) -> None:
+    """Print a formatted comparison table to stdout."""
+    print("\n=== Baseline vs Hybrid Comparison ===")
+    col_w, num_w = 38, 14
+    print("  ".join([f"{'Model':{col_w}}"] + [f"{c:{num_w}}" for c in scalar_keys]))
+    for row in (baseline_row, hybrid_row):
+        row_parts = [f"{str(row['model']):{col_w}}"] + [
+            f"{float(row[k]):{num_w}.4f}"  # type: ignore[arg-type]
+            for k in scalar_keys
+        ]
+        print("  ".join(row_parts))
+
+
+def _plot_comparison_chart(
+    baseline_row: dict[str, str | float],
+    hybrid_row: dict[str, str | float],
+    figures_dir: str,
+) -> None:
+    """Save a grouped bar chart comparing baseline vs hybrid to figures_dir."""
+    import matplotlib.pyplot as plt
+
+    metrics_to_plot = ["accuracy", "weighted_f1", "jailbreak_recall", "indirect_recall"]
+    x = np.arange(len(metrics_to_plot))
+    width = 0.35
+    baseline_vals = [float(baseline_row[m]) for m in metrics_to_plot]  # type: ignore[arg-type]
+    hybrid_vals = [float(hybrid_row[m]) for m in metrics_to_plot]  # type: ignore[arg-type]
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.bar(x - width / 2, baseline_vals, width, label="Baseline", color="steelblue")
+    ax.bar(x + width / 2, hybrid_vals, width, label="Hybrid (Stage A)", color="coral")
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(metrics_to_plot, rotation=15, ha="right")
+    ax.set_ylim(0, 1.1)
+    ax.set_ylabel("Score")
+    ax.set_title("Baseline vs Hybrid Comparison")
+    ax.legend()
+    plt.tight_layout()
+    cmp_path = os.path.join(figures_dir, "baseline_vs_hybrid.png")
+    fig.savefig(cmp_path)
+    plt.close(fig)
+    logger.info("baseline_vs_hybrid_chart_saved", extra={"path": cmp_path})
 
 
 # ---------------------------------------------------------------------------
@@ -619,76 +704,10 @@ def compare_baseline_vs_hybrid(
         "date": today,
     }
 
-    # Update results.json
-    os.makedirs(os.path.dirname(results_path), exist_ok=True)
-    if os.path.exists(results_path):
-        with open(results_path) as f:
-            results: dict[str, Any] = json.load(f)
-        results["benchmarks"] = [
-            b
-            for b in results.get("benchmarks", [])
-            if b.get("model")
-            not in (
-                str(baseline_row["model"]),
-                str(hybrid_row["model"]),
-            )
-        ]
-        results["benchmarks"].extend([baseline_row, hybrid_row])
-    else:
-        results = {
-            "project": "P1-Hybrid-Jailbreak-Detector",
-            "benchmarks": [baseline_row, hybrid_row],
-        }
+    _merge_results_json(results_path, baseline_row, hybrid_row)
+    _print_comparison_table(baseline_row, hybrid_row, _scalar_keys)
+    _plot_comparison_chart(baseline_row, hybrid_row, figures_dir)
 
-    with open(results_path, "w") as f:
-        json.dump(results, f, indent=2)
-    logger.info("results_json_updated", extra={"path": results_path})
-
-    # Print comparison table
-    print("\n=== Baseline vs Hybrid Comparison ===")
-    col_w = 38
-    num_w = 14
-    header_parts = [f"{'Model':{col_w}}"] + [f"{c:{num_w}}" for c in _scalar_keys]
-    print("  ".join(header_parts))
-    for row in (baseline_row, hybrid_row):
-        row_parts = [f"{str(row['model']):{col_w}}"] + [
-            f"{float(row[k]):{num_w}.4f}"  # type: ignore[arg-type]
-            for k in _scalar_keys
-        ]
-        print("  ".join(row_parts))
-
-    # Comparison bar chart
-    metrics_to_plot = [
-        "accuracy",
-        "weighted_f1",
-        "jailbreak_recall",
-        "indirect_recall",
-    ]
-    x = np.arange(len(metrics_to_plot))
-    width = 0.35
-    baseline_vals = [
-        float(baseline_row[m]) for m in metrics_to_plot  # type: ignore[arg-type]
-    ]
-    hybrid_vals = [
-        float(hybrid_row[m]) for m in metrics_to_plot  # type: ignore[arg-type]
-    ]
-
-    fig, ax = plt.subplots(figsize=(10, 6))
-    ax.bar(x - width / 2, baseline_vals, width, label="Baseline", color="steelblue")
-    ax.bar(x + width / 2, hybrid_vals, width, label="Hybrid (Stage A)", color="coral")
-    ax.set_xticks(list(x))
-    ax.set_xticklabels(metrics_to_plot, rotation=15, ha="right")
-    ax.set_ylim(0, 1.1)
-    ax.set_ylabel("Score")
-    ax.set_title("Baseline vs Hybrid Comparison")
-    ax.legend()
-    plt.tight_layout()
-    cmp_path = os.path.join(figures_dir, "baseline_vs_hybrid.png")
-    fig.savefig(cmp_path)
-    plt.close(fig)
-    logger.info("baseline_vs_hybrid_chart_saved", extra={"path": cmp_path})
-
-    # W&B Weave logging (optional, C7/weave config)
     if config.get("weave", {}).get("enabled", False):
         try:
             import weave  # type: ignore[import-untyped]

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -72,6 +72,104 @@ def _tokenize_dataset(
     return _DS()
 
 
+def _early_stop_check(
+    val_loss: float,
+    best_val_loss: float,
+    bad_epochs: int,
+    patience: int,
+    epoch: int,
+) -> tuple[float, int, bool]:
+    """Update early-stopping counters; return (new_best_loss, new_bad_epochs, stop)."""
+    if val_loss < best_val_loss:
+        return val_loss, 0, False
+    bad_epochs += 1
+    stop = bad_epochs >= patience
+    if stop:
+        logger.info("early stopping", extra={"epoch": epoch, "patience": patience})
+    return best_val_loss, bad_epochs, stop
+
+
+def _log_weave_epoch(
+    epoch: int, val_loss: float, val_acc: float, val_f1: float
+) -> None:
+    """Optionally emit epoch metrics to W&B Weave when ENABLE_WEAVE=1."""
+    if os.environ.get("ENABLE_WEAVE") != "1":
+        return
+    try:
+        import weave
+
+        weave.log({"epoch": epoch, "val_loss": val_loss, "val_acc": val_acc, "val_f1": val_f1})
+    except Exception as exc:  # pragma: no cover
+        logger.warning("weave log failed", extra={"err": str(exc)})
+
+
+def _run_train_epoch(
+    model: Any,
+    train_loader: Any,
+    optimizer: Any,
+    scheduler: Any,
+    loss_fn: Any,
+    device: Any,
+) -> float:
+    """Run one full training epoch; return cumulative loss."""
+    import torch
+    from torch import nn
+
+    model.train()
+    epoch_loss = 0.0
+    for batch in train_loader:
+        batch = {k: v.to(device) for k, v in batch.items()}
+        optimizer.zero_grad()
+        with torch.autocast(device.type, enabled=(device.type == "cuda")):
+            out = model(
+                input_ids=batch["input_ids"],
+                attention_mask=batch["attention_mask"],
+            )
+            loss = loss_fn(out.logits, batch["labels"])
+        loss.backward()
+        nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        optimizer.step()
+        scheduler.step()
+        epoch_loss += float(loss.item())
+    return epoch_loss
+
+
+def _run_validation(
+    model: Any,
+    val_loader: Any,
+    loss_fn: Any,
+    device: Any,
+) -> tuple[float, float, float]:
+    """Run validation; return (val_loss, val_acc, val_f1)."""
+    import torch
+    from sklearn.metrics import f1_score
+
+    model.eval()
+    val_loss = 0.0
+    correct = 0
+    seen = 0
+    all_preds: list[int] = []
+    all_labels: list[int] = []
+    with torch.no_grad():
+        for batch in val_loader:
+            batch = {k: v.to(device) for k, v in batch.items()}
+            with torch.autocast(device.type, enabled=(device.type == "cuda")):
+                out = model(
+                    input_ids=batch["input_ids"],
+                    attention_mask=batch["attention_mask"],
+                )
+                val_loss += float(loss_fn(out.logits, batch["labels"]).item())
+            preds = out.logits.argmax(dim=-1)
+            correct += int((preds == batch["labels"]).sum().item())
+            seen += int(batch["labels"].shape[0])
+            all_preds.extend([int(x) for x in preds.cpu().tolist()])
+            all_labels.extend([int(x) for x in batch["labels"].cpu().tolist()])
+
+    val_acc = correct / max(seen, 1)
+    val_f1 = float(f1_score(all_labels, all_preds, average="macro", zero_division=0))
+    return val_loss, val_acc, val_f1
+
+
 def train_stage_a(config: dict[str, Any]) -> None:
     """Train ModernBERT + LoRA Stage A classifier.
 
@@ -81,7 +179,6 @@ def train_stage_a(config: dict[str, Any]) -> None:
     import mlflow
     import torch
     from peft import LoraConfig, TaskType, get_peft_model
-    from sklearn.metrics import f1_score
     from torch import nn
     from torch.optim import AdamW
     from torch.utils.data import DataLoader
@@ -188,50 +285,13 @@ def train_stage_a(config: dict[str, Any]) -> None:
         best_val_f1 = 0.0
         bad_epochs = 0
         for epoch in range(epochs):
-            model.train()
-            epoch_loss = 0.0
-            for batch in train_loader:
-                batch = {k: v.to(device) for k, v in batch.items()}
-                optimizer.zero_grad()
-                with torch.autocast(device.type, enabled=(device.type == "cuda")):
-                    out = model(
-                        input_ids=batch["input_ids"],
-                        attention_mask=batch["attention_mask"],
-                    )
-                    loss = loss_fn(out.logits, batch["labels"])
-                loss.backward()
-                nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-                optimizer.step()
-                scheduler.step()
-                epoch_loss += float(loss.item())
-
-            model.eval()
-            val_loss = 0.0
-            correct = 0
-            seen = 0
-            all_preds: list[int] = []
-            all_labels_val: list[int] = []
-            with torch.no_grad():
-                for batch in val_loader:
-                    batch = {k: v.to(device) for k, v in batch.items()}
-                    with torch.autocast(device.type, enabled=(device.type == "cuda")):
-                        out = model(
-                            input_ids=batch["input_ids"],
-                            attention_mask=batch["attention_mask"],
-                        )
-                        val_loss += float(loss_fn(out.logits, batch["labels"]).item())
-                    preds = out.logits.argmax(dim=-1)
-                    correct += int((preds == batch["labels"]).sum().item())
-                    seen += int(batch["labels"].shape[0])
-                    all_preds.extend([int(x) for x in preds.cpu().tolist()])
-                    all_labels_val.extend(
-                        [int(x) for x in batch["labels"].cpu().tolist()]
-                    )
-
-            val_acc = correct / max(seen, 1)
-            val_f1 = float(
-                f1_score(all_labels_val, all_preds, average="macro", zero_division=0)
+            epoch_loss = _run_train_epoch(
+                model, train_loader, optimizer, scheduler, loss_fn, device
             )
+            val_loss, val_acc, val_f1 = _run_validation(
+                model, val_loader, loss_fn, device
+            )
+
             if val_f1 > best_val_f1:
                 best_val_f1 = val_f1
             logger.info(
@@ -249,31 +309,13 @@ def train_stage_a(config: dict[str, Any]) -> None:
             mlflow.log_metric("val_acc", val_acc, step=epoch)
             mlflow.log_metric("val_f1", val_f1, step=epoch)
 
-            if os.environ.get("ENABLE_WEAVE") == "1":
-                try:
-                    import weave
+            _log_weave_epoch(epoch, val_loss, val_acc, val_f1)
 
-                    weave.log(
-                        {
-                            "epoch": epoch,
-                            "val_loss": val_loss,
-                            "val_acc": val_acc,
-                            "val_f1": val_f1,
-                        }
-                    )
-                except Exception as exc:  # pragma: no cover
-                    logger.warning("weave log failed", extra={"err": str(exc)})
-
-            if val_loss < best_val_loss:
-                best_val_loss = val_loss
-                bad_epochs = 0
-            else:
-                bad_epochs += 1
-                if bad_epochs >= patience:
-                    logger.info(
-                        "early stopping", extra={"epoch": epoch, "patience": patience}
-                    )
-                    break
+            best_val_loss, bad_epochs, stop = _early_stop_check(
+                val_loss, best_val_loss, bad_epochs, patience, epoch
+            )
+            if stop:
+                break
 
         mlflow.log_metric("best_val_f1", best_val_f1)
 


### PR DESCRIPTION
## Summary
- `collect_safe_corpus` C(11) → clean: extracted `_collect_from_c4` and `_collect_from_openwebtext`
- `collect_all_sources` C(13) → clean: extracted `_collect_frames` with dispatch dict
- `generate_explainability_samples` C(14) → clean: extracted `_save_one_attribution`
- `compare_baseline_vs_hybrid` C(16) → clean: extracted `_merge_results_json`, `_print_comparison_table`, `_plot_comparison_chart`
- `train_stage_a` C(18) → clean: extracted `_run_train_epoch`, `_run_validation`, `_early_stop_check`, `_log_weave_epoch`

## Test plan
- [x] `radon cc src/ -nc` → no output (all functions grade A or B)
- [x] 4 training tests pass
- [x] 10 evaluation tests pass
- [x] 34 collect + pipeline tests pass

Closes #35