### PR TITLE
docs: raise docstring coverage to 82% (interrogate gate)

### DIFF
--- a/src/api/feedback.py
+++ b/src/api/feedback.py
@@ -18,12 +18,14 @@ class FeedbackStore:
     """SQLite-backed feedback loop + correction stats."""
 
     def __init__(self, db_path: str, min_corrections_for_retrain: int = 50) -> None:
+        """Create or open the SQLite store at db_path; initialise schema."""
         self._db_path = db_path
         self._min_for_retrain = min_corrections_for_retrain
         self._lock = threading.Lock()
         self._init_db()
 
     def _init_db(self) -> None:
+        """Create the corrections table if it does not already exist."""
         with sqlite3.connect(self._db_path) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS corrections (
@@ -40,6 +42,7 @@ class FeedbackStore:
             conn.commit()
 
     def submit_correction(self, request: FeedbackRequest) -> dict[str, Any]:
+        """Insert one correction row; return stored=True + total count."""
         ts = datetime.now(timezone.utc).isoformat()
         with self._lock:
             with sqlite3.connect(self._db_path) as conn:
@@ -71,6 +74,7 @@ class FeedbackStore:
         return {"stored": True, "total_corrections": total}
 
     def get_stats(self) -> dict[str, Any]:
+        """Return total corrections, breakdown by type/label, retrain_ready flag."""
         with sqlite3.connect(self._db_path) as conn:
             total: int = conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0]
 

--- a/src/evaluation/redteam.py
+++ b/src/evaluation/redteam.py
@@ -16,7 +16,11 @@ from src.logger import get_logger
 
 
 class _PipelineProtocol(Protocol):
-    def classify(self, request: ClassifyRequest) -> ClassifyResponse: ...
+    """Structural interface satisfied by HybridPipeline and test fakes."""
+
+    def classify(self, request: ClassifyRequest) -> ClassifyResponse:
+        """Classify a single request and return a ClassifyResponse."""
+        ...
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +147,7 @@ def _run_single_turn(
     pipeline: _PipelineProtocol,
     attacks: list[str],
 ) -> dict[str, Any]:
+    """Classify a list of attack strings; return block/allow/review counts."""
     n_blocked = n_human = n_allowed = 0
     for text in attacks:
         try:
@@ -170,6 +175,7 @@ def _run_requests(
     pipeline: _PipelineProtocol,
     requests: list[ClassifyRequest],
 ) -> dict[str, Any]:
+    """Classify a list of ClassifyRequests; return block/allow/review counts."""
     n_blocked = n_human = n_allowed = 0
     for req in requests:
         try:
@@ -198,6 +204,7 @@ def _run_multi_turn(
     requests: list[ClassifyRequest],
     op_name: str,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Classify multi-turn requests; return (stats, critical_findings)."""
     n_blocked = n_human = n_allowed = 0
     critical: list[dict[str, Any]] = []
     for req in requests:
@@ -247,6 +254,7 @@ class RedTeamHarness:
         pipeline: _PipelineProtocol,
         config: dict[str, Any],
     ) -> None:
+        """Wire pipeline + load redteam config (seed, n_mutations, output_dir)."""
         self._pipeline = pipeline
         self._config = config
         rt_cfg: dict[str, Any] = config.get("redteam", {})

--- a/src/hybrid/explain.py
+++ b/src/hybrid/explain.py
@@ -25,6 +25,7 @@ class TokenExplainer:
         self._logger = get_logger(__name__)
 
     def _ensure_lig(self) -> None:
+        """Build LayerIntegratedGradients on first call; no-op thereafter."""
         if self._lig is not None:
             return
         # pragma: no cover - heavy captum import path
@@ -36,9 +37,11 @@ class TokenExplainer:
         )
 
     def _forward_fn(self, input_ids: Any) -> Any:  # pragma: no cover
+        """Forward pass returning max logit — required by LayerIntegratedGradients."""
         return self._model(input_ids).logits.max(dim=-1).values
 
     def explain(self, text: str) -> list[dict[str, str | float]]:
+        """Return token-level attribution scores via integrated gradients."""
         self._ensure_lig()
         assert self._lig is not None
 

--- a/src/hybrid/normalize.py
+++ b/src/hybrid/normalize.py
@@ -58,6 +58,7 @@ class InputNormalizer:
     """Homoglyph mapping, zero-width char stripping, leetspeak normalization."""
 
     def __init__(self, config: dict[str, Any]) -> None:
+        """Load normalization flags from config.model.normalization."""
         norm_cfg: dict[str, Any] = config.get("model", {}).get("normalization", {})
         self._strip_zw: bool = bool(norm_cfg.get("strip_zero_width", True))
         self._map_homoglyphs: bool = bool(norm_cfg.get("normalize_homoglyphs", True))
@@ -108,6 +109,7 @@ class InputNormalizer:
         return result, applied
 
     def _convert_leetspeak(self, text: str) -> str:
+        """Replace leet digits adjacent to letters; leave standalone numerics."""
         # Only convert digits that sit adjacent to a letter — prevents mangling
         # legitimate numerics like "ip 127.0.0.1" or "year 2024".
         chars = list(text)

--- a/src/hybrid/similarity.py
+++ b/src/hybrid/similarity.py
@@ -18,6 +18,7 @@ class SimilarityGate:
         index: Optional[Any] = None,
         attack_texts: Optional[list[str]] = None,
     ) -> None:
+        """Load similarity config; encoder/index are injectable for testing."""
         sim_cfg: dict[str, Any] = config["model"]["similarity"]
         self._model_name: str = str(sim_cfg["model_name"])
         self._threshold: float = float(sim_cfg["threshold"])
@@ -28,6 +29,7 @@ class SimilarityGate:
         self._logger = get_logger(__name__)
 
     def _ensure_encoder(self) -> None:
+        """Lazy-load SentenceTransformer encoder on first use."""
         if self._encoder is None:  # pragma: no cover - heavy download path
             from sentence_transformers import SentenceTransformer
 

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -22,6 +22,7 @@ MERGED_DIR = Path("models/stage_a_merged")
 
 
 def _compute_class_weights(labels: np.ndarray, num_labels: int) -> np.ndarray:
+    """Return inverse-frequency class weights for CrossEntropyLoss."""
     counts = np.bincount(labels.astype(int), minlength=num_labels).astype(float)
     counts[counts == 0] = 1.0
     weights = labels.shape[0] / (num_labels * counts)
@@ -34,6 +35,7 @@ def _tokenize_dataset(
     labels: list[int],
     max_length: int,
 ) -> Any:
+    """Tokenize texts + labels into a PyTorch Dataset; warns on truncation."""
     import torch
     from torch.utils.data import Dataset
 
@@ -49,7 +51,10 @@ def _tokenize_dataset(
         )
 
     class _DS(Dataset):  # type: ignore[type-arg,misc]
+        """Minimal PyTorch Dataset wrapping tokenized inputs and labels."""
+
         def __init__(self) -> None:
+            """Tokenize all texts at construction time."""
             self.enc = tokenizer(
                 texts,
                 truncation=True,
@@ -60,9 +65,11 @@ def _tokenize_dataset(
             self.labels = torch.tensor(labels, dtype=torch.long)
 
         def __len__(self) -> int:
+            """Return the number of samples."""
             return int(self.labels.shape[0])
 
         def __getitem__(self, idx: int) -> dict[str, Any]:
+            """Return input_ids, attention_mask and label for index idx."""
             return {
                 "input_ids": self.enc["input_ids"][idx],
                 "attention_mask": self.enc["attention_mask"][idx],


### PR DESCRIPTION
## Summary
- Adds 23 docstrings across 6 files: redteam.py, train.py, feedback.py, explain.py, normalize.py, similarity.py
- Raises `interrogate` from 72.0% → 82.2% (target: ≥80%)
- All gates pass: black, isort, flake8, mypy, bandit, pytest (192 tests, 85% cov)

Closes #42

## Test plan
- [ ] `interrogate src/ --fail-under=80` exits 0 with 82.2%
- [ ] `py -3.10 -m pytest tests/ -v --tb=short --cov=src --cov-fail-under=70` → 192 passed
- [ ] `flake8 src/ tests/` → clean (no E501 from new docstrings)
- [ ] `mypy src/` → clean