### PR TITLE
feat: multi-stage Dockerfile with non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Git and CI
+.git/
+.github/
+.claude/
+.mypy_cache/
+.pytest_cache/
+.coverage
+*.egg-info/
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Secrets and personal files
+.env
+CLAUDE.md
+learning_log.md
+explain.md
+carry.md
+.secrets.baseline
+
+# Large model artifacts — mount as volumes in production
+models/stage_a_adapter/
+models/stage_a_merged/
+models/stage_a_onnx/
+models/baseline/
+
+# Data — mount as volumes in production
+data/
+
+# Dev / test artifacts
+tests/
+reports/
+mlruns/
+mlflow.db
+venv/
+hf_space/
+
+# Zip artifacts (Kaggle exports)
+*.zip
+
+# Notebooks
+*.ipynb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+# Stage 1: builder — install all Python dependencies
+FROM python:3.10-slim AS builder
+
+WORKDIR /build
+
+# Install build tools needed by some packages (e.g. faiss-cpu, scipy)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Stage 2: runtime — lean image, non-root user
+FROM python:3.10-slim AS runtime
+
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
+
+WORKDIR /app
+
+# Create non-root user
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+# Copy application source and config only — models are mounted as a volume
+COPY src/ ./src/
+COPY config/ ./config/
+COPY pyproject.toml .
+
+# models/ directory placeholder so volume mount works without error
+RUN mkdir -p models/stage_a_onnx models/baseline data/faiss_index
+
+# Own the working directory
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8000
+
+# TOGETHER_API_KEY must be passed at runtime via --env or --env-file
+# Never bake secrets into the image
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Two-stage build: `builder` installs deps, `runtime` copies only src/, config/, pyproject.toml
- Non-root `appuser` created with `groupadd`/`useradd` — no root in production
- `models/` NOT copied — mounted as volume at runtime
- `TOGETHER_API_KEY` passed via `--env` flag, never baked into image
- `.dockerignore` excludes venv, tests, data, model files, secrets, .claude/

## How to run
```bash
docker build -t p1-hybrid-jailbreak-detector .
docker run --rm -p 8000:8000 \
  --env TOGETHER_API_KEY=<key> \
  -v $(pwd)/models:/app/models \
  p1-hybrid-jailbreak-detector
curl http://localhost:8000/api/v1/health
```

## Test plan
- [ ] `docker build` completes without error
- [ ] Container starts and health endpoint responds 200
- [ ] `docker run` as appuser (verify with `docker exec ... whoami`)
- [ ] No secrets or model weights baked into image layers

Closes #46