### PR TITLE
feat: INT8 dynamic ONNX quantization for Stage A (1.78x CPU speedup)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,6 +48,7 @@ feedback:
 
 onnx:
   export_path: "models/stage_a_onnx/"
+  model_file: "model_int8.onnx"
   optimize: true
 
 training:

--- a/scripts/quantize_onnx.py
+++ b/scripts/quantize_onnx.py
@@ -1,0 +1,58 @@
+"""INT8 dynamic quantization for Stage A ONNX model.
+
+Reduces model size ~4x and speeds up CPU inference by 1.5-2x
+with no GPU required and negligible accuracy loss.
+
+Usage:
+    py -3.10 scripts/quantize_onnx.py
+"""
+
+import time
+
+import numpy as np
+import onnxruntime as ort
+from onnxruntime.quantization import QuantType, quantize_dynamic
+
+FP32_PATH = "models/stage_a_onnx/model.onnx"
+INT8_PATH = "models/stage_a_onnx/model_int8.onnx"
+N_RUNS = 100
+SEQ_LEN = 128
+
+
+def benchmark(path: str) -> float:
+    """Run N_RUNS inference passes and return average latency in ms."""
+    sess = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+    dummy = {
+        "input_ids": np.ones((1, SEQ_LEN), dtype=np.int64),
+        "attention_mask": np.ones((1, SEQ_LEN), dtype=np.int64),
+    }
+    # Warm-up
+    for _ in range(5):
+        sess.run(None, dummy)
+    t0 = time.perf_counter()
+    for _ in range(N_RUNS):
+        sess.run(None, dummy)
+    return (time.perf_counter() - t0) / N_RUNS * 1000
+
+
+def main() -> None:
+    """Quantize fp32 ONNX to INT8 and print speedup ratio."""
+    print(f"Quantizing {FP32_PATH} -> {INT8_PATH} ...")
+    quantize_dynamic(
+        FP32_PATH,
+        INT8_PATH,
+        weight_type=QuantType.QInt8,
+    )
+    print("Quantization complete.")
+
+    fp32_ms = benchmark(FP32_PATH)
+    int8_ms = benchmark(INT8_PATH)
+    ratio = fp32_ms / int8_ms
+
+    print(f"fp32 : {fp32_ms:.1f} ms avg ({N_RUNS} runs)")
+    print(f"int8 : {int8_ms:.1f} ms avg ({N_RUNS} runs)")
+    print(f"Speedup ratio: {ratio:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/stage_a_manifest.json
+++ b/stage_a_manifest.json
@@ -1,0 +1,23 @@
+{
+  "model_name": "answerdotai/ModernBERT-base",
+  "lora_r": 16,
+  "lora_alpha": 32,
+  "target_modules": [
+    "Wqkv",
+    "Wo"
+  ],
+  "max_length": 512,
+  "training_samples": 13974,
+  "epochs_completed": 5,
+  "best_val_f1": 0.9804901613410628,
+  "training_device": "T4",
+  "onnx_exported": true,
+  "onnx_path": "models/stage_a_onnx/",
+  "onnx_int8_exported": true,
+  "onnx_int8_path": "models/stage_a_onnx/model_int8.onnx",
+  "onnx_speedup_ratio": 1.78,
+  "onnx_fp32_latency_ms": 334.8,
+  "onnx_int8_latency_ms": 188.4,
+  "date": "2026-04-17",
+  "int8_quantized_date": "2026-04-24"
+}


### PR DESCRIPTION
## Summary
- Added `scripts/quantize_onnx.py` — applies `quantize_dynamic` (QInt8) from `onnxruntime.quantization`
- Benchmark measured on 100 dummy inputs (seq_len=128, CPUExecutionProvider):
  - fp32: 334.8 ms avg
  - int8: 188.4 ms avg
  - **Speedup: 1.78x** (target was 1.5–2.0x ✅)
- `stage_a_manifest.json` updated: `onnx_int8_exported=true`, `onnx_speedup_ratio=1.78`
- `config/config.yaml`: added `onnx.model_file: model_int8.onnx` as default

## How it works
INT8 dynamic quantization replaces FP32 weight tensors with INT8 at load time. Activations remain FP32. No calibration dataset needed — pure weight-only quantization. Useful for CPU inference where matrix ops dominate.

## Test plan
- [x] `venv/Scripts/python.exe scripts/quantize_onnx.py` runs successfully
- [x] `models/stage_a_onnx/model_int8.onnx` created
- [x] Speedup 1.78x confirmed via benchmark
- [x] All 192 tests pass, 85% coverage
- [x] Full gate: black→isort→flake8→mypy→bandit→pytest all green

Closes #47